### PR TITLE
Critical Fix - If condition when title is empty

### DIFF
--- a/service.py
+++ b/service.py
@@ -148,12 +148,11 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "":
-        if xbmc.Player().isPlaying():
-            log("VideoPlayer.OriginalTitle not found")
-            item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
-        else:
-            item['title'] = "Search For..."  # Needed to avoid showing previous search result.
+    if item['title'] == "" and xbmc.Player().isPlaying():
+        log("VideoPlayer.OriginalTitle not found")
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+    else:
+        item['title'] = "Search For..." # Needed to avoid showing previous search result.
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -141,18 +141,16 @@ if params['action'] in ['search', 'manualsearch']:
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = ""
+        item['title'] = "Search For..." # Needed to avoid showing previous search result.
         item['file_original_path'] = ""
         item['3let_language'] = []
         item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "" and xbmc.Player().isPlaying():
+    if item['title'] == "":
         log("VideoPlayer.OriginalTitle not found")
         item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
-    else:
-        item['title'] = "Search For..." # Needed to avoid showing previous search result.
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -153,7 +153,7 @@ if params['action'] in ['search', 'manualsearch']:
             log("VideoPlayer.OriginalTitle not found")
             item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
         else:
-            item['title'] = "Search For..." # Needed to avoid showing previous search result.
+            item['title'] = "Search For..."  # Needed to avoid showing previous search result.
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:


### PR DESCRIPTION
Salts, Quasar and Local content for example gives empty title from the player, while exodus and specto gives a title. So currently in Exodus case it always goes to the "else" with the "fake" title and didn't show results.
When with salts it go into the right place and fix the title.

The fix:
Basically, put the "fake" title few lines before, in the first condition if kodi is playing (Instead of the empty title as it now), and bring back the if condition when title is empty as it was before (without checking there if kodi is playing).

I check this and now it's ok.
